### PR TITLE
docs: include keyserver in gpg instructions and notice

### DIFF
--- a/Documentation/distributions.md
+++ b/Documentation/distributions.md
@@ -146,7 +146,7 @@ upgrade manually.
 
 ### rpm-based 
 ```
-gpg --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
+gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
 wget https://github.com/rkt/rkt/releases/download/v1.30.0/rkt-1.30.0-1.x86_64.rpm
 wget https://github.com/rkt/rkt/releases/download/v1.30.0/rkt-1.30.0-1.x86_64.rpm.asc
 gpg --verify rkt-1.30.0-1.x86_64.rpm.asc
@@ -155,7 +155,7 @@ sudo rpm -Uvh rkt-1.30.0-1.x86_64.rpm
 
 ### deb-based
 ```
-gpg --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
+gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
 wget https://github.com/rkt/rkt/releases/download/v1.30.0/rkt_1.30.0-1_amd64.deb
 wget https://github.com/rkt/rkt/releases/download/v1.30.0/rkt_1.30.0-1_amd64.deb.asc
 gpg --verify rkt_1.30.0-1_amd64.deb.asc

--- a/Documentation/distributions.md
+++ b/Documentation/distributions.md
@@ -145,6 +145,7 @@ Currently the rkt upstream project does not maintain its own repository, so user
 upgrade manually.
 
 ### rpm-based 
+**Note:** The example keyserver argument should be omitted if you already have a keyserver configured or you do not trust the SKS Keyservers
 ```
 gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
 wget https://github.com/rkt/rkt/releases/download/v1.30.0/rkt-1.30.0-1.x86_64.rpm
@@ -154,6 +155,7 @@ sudo rpm -Uvh rkt-1.30.0-1.x86_64.rpm
 ```
 
 ### deb-based
+**Note:** The example keyserver argument should be omitted if you already have a keyserver configured or you do not trust the SKS Keyservers
 ```
 gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
 wget https://github.com/rkt/rkt/releases/download/v1.30.0/rkt_1.30.0-1_amd64.deb


### PR DESCRIPTION
docs: include keyserver in gpg instructions and notice.  Closes issue issue #3919.